### PR TITLE
Add services to cloudbuild network

### DIFF
--- a/reports/docker-compose.yml
+++ b/reports/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   reports_db:
     image: postgres:16
     container_name: reports_db
+    networks:
+      - cloudbuild
     ports:
       - "5433:5432"
     env_file:
@@ -12,6 +14,8 @@ services:
   reports_app:
     build: .
     container_name: reports_app
+    networks:
+      - cloudbuild
     ports:
       - "8000:8000"
     depends_on:
@@ -21,4 +25,8 @@ services:
     
 volumes:
   reports_db:
-
+  
+  
+networks:
+  cloudbuild:
+    external: true


### PR DESCRIPTION
I have added the cloudbuild (a custom docker network to facilitate communication amongst services) to allow nginx to find it and proxy it.